### PR TITLE
[CHORE] Adds support for publishing to NPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 dist
 .idea
 *.iml
+.DS_Store

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  hooks: {
+    'prepare-commit-msg': 'git-commit-template',
+    'pre-commit':
+      'npm --no-git-tag-version version patch && git add package.json && git add package-lock.json && lint-staged'
+  }
+};

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ## secrets-manager-signature-tools
 
-[![codecov.io Code Coverage](https://img.shields.io/codecov/c/github/awslabs/secrets-manager-signature-tools.svg?maxAge=2592000)](https://codecov.io/github/awslabs/secrets-manager-signature-tools?branch=master)
-
 A lightweight wrapper over NodeJS native crypto library for content signing and verification. This library interfaces with AWS Secrets Manager (ASM) to fetch stored secrets for the signature processes to reduce boilerplate secret management in your code.
 
 You can use this library for code signing with AWS Secrets Manager in your JavaScript/TypeScript applications. For TS, you do not need separate typings package to be installed; you'd find the typings as part of this package itself.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets-manager-signature-tools",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,33 +1,28 @@
 {
   "name": "secrets-manager-signature-tools",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Utility to use secrets from AWS Secrets Manager for cryptographic signature generation and verification",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/awslabs/secrets-manager-signature-tools.git"
   },
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "author": "dalmia.anmol+github@gmail.com",
+  "homepage": "https://github.com/awslabs/secrets-manager-signature-tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
     "node": ">=8.0.0"
   },
+  "files": ["dist"],
   "scripts": {
     "build": "tsc -p .",
     "clean": "rm -rf dist ; rm -rf coverage",
     "coverage": "jest --coverage",
-    "create": "npm-run-all build coverage lint",
+    "create": "npm-run-all coverage build lint",
     "lint": "eslint 'src/**/*'",
     "lint:fix": "eslint --fix 'src/**/*'",
-    "precommit": "npm --no-git-tag-version version patch && git add package.json && git add package-lock.json",
     "test": "jest"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run precommit && lint-staged",
-      "prepare-commit-msg": "git-commit-template"
-    }
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx,json,css,md}": ["prettier --write", "git add"],


### PR DESCRIPTION
In this commit, made changes to package.json to support publishing the
code to NPM public registry.

Also, removed the code coverage badge from README since we do not have
a CI ready yet.

[TESTING]

Manually verified output for `npm pack` and `npm version` commands to
see the published artefacts to NPM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
